### PR TITLE
Allow touch column to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,21 @@ class Post
   counter_cache_on column: :posts_count, # users.posts_count
                    relation: :user,
                    relation_class_name: "User",
+                   method: :calculate_posts_count # This is a method on the user.
+end
+```
+
+#### To allow a timestamp to be updated:
+
+```ruby
+class Post
+  include Counter::Cache
+
+  counter_cache_on column: :posts_count, # users.posts_count
+                   relation: :user,
+                   relation_class_name: "User",
                    method: :calculate_posts_count, # This is a method on the user.
+                   touch_column: :posts_updated_at
 end
 ```
 

--- a/lib/counter/cache/counters/buffer_counter/enqueuer.rb
+++ b/lib/counter/cache/counters/buffer_counter/enqueuer.rb
@@ -11,15 +11,16 @@ module Counter
           private
 
           def create_and_enqueue(delay, cached)
+            parameters = { relation_class_name: relation_class,
+                           relation_id: relation_id,
+                           column: options.column,
+                           method: options.method,
+                           cache: cached,
+                           counter: counter_class_name }
+            parameters[:touch_column] = options.touch_column unless options.touch_column.nil?
             options.worker_adapter.enqueue(delay,
                                            source_object_class_name,
-                                           { relation_class_name: relation_class,
-                                             relation_id: relation_id,
-                                             column: options.column,
-                                             touch_column: options.touch_column,
-                                             method: options.method,
-                                             cache: cached,
-                                             counter: counter_class_name })
+                                           parameters)
           end
         end
       end

--- a/lib/counter/cache/counters/buffer_counter/enqueuer.rb
+++ b/lib/counter/cache/counters/buffer_counter/enqueuer.rb
@@ -16,6 +16,7 @@ module Counter
                                            { relation_class_name: relation_class,
                                              relation_id: relation_id,
                                              column: options.column,
+                                             touch_column: options.touch_column,
                                              method: options.method,
                                              cache: cached,
                                              counter: counter_class_name })

--- a/lib/counter/cache/counters/buffer_counter/saver.rb
+++ b/lib/counter/cache/counters/buffer_counter/saver.rb
@@ -18,6 +18,7 @@ module Counter
 
           def save_new_value!(value)
             relation_object.send("#{options.column}=", value)
+            relation_object.send("#{options.touch_column}=", DateTime.now) if options.touch_column
             relation_object.save!(validate: false)
           end
 

--- a/lib/counter/cache/options_parser.rb
+++ b/lib/counter/cache/options_parser.rb
@@ -13,6 +13,10 @@ module Counter
         options[:column]
       end
 
+      def touch_column
+        options[:touch_column]
+      end
+
       def relation
         options[:relation]
       end

--- a/spec/lib/counter/cache/buffer_counter/enqueuer_spec.rb
+++ b/spec/lib/counter/cache/buffer_counter/enqueuer_spec.rb
@@ -2,55 +2,106 @@ require 'spec_helper'
 
 RSpec.describe Counter::Cache::Counters::BufferCounter::Enqueuer do
   let(:worker_adapter) { double }
-  let(:options) { double(worker_adapter: worker_adapter,
-                         wait: 10,
-                         column: "boo",
-                         touch_column: "boo_updated_at",
-                         method: "calculate_boo",
-                         cached?: true,
-                         recalculation?: false,
-                         recalculation_delay: 20) }
 
   let(:source_object_class_name) { "BooUser" }
   let(:relation_id) { 1 }
   let(:relation_type) { "Boo" }
 
-  let(:enqueuer) { Counter::Cache::Counters::BufferCounter::Enqueuer.new(options, source_object_class_name, relation_id, relation_type, "SuperCounter") }
-
   describe '#enqueue' do
-    before do
-      expect(worker_adapter).to receive(:enqueue).with(10,
-                                                       "BooUser",
-                                                       { relation_class_name: "Boo",
-                                                         relation_id: 1,
-                                                         column: "boo",
-                                                         touch_column: "boo_updated_at",
-                                                         method: "calculate_boo",
-                                                         cache: true,
-                                                         counter: "SuperCounter" })
-    end
-
-    describe 'when recalculation is true' do
+    context "without touch column" do
       before do
-        expect(options).to receive(:recalculation?).and_return(true)
+        @options =  double(worker_adapter: worker_adapter,
+                           wait: 10,
+                           column: "boo",
+                           method: "calculate_boo",
+                           cached?: true,
+                           recalculation?: false,
+                           recalculation_delay: 20)
+
+        @enqueuer = Counter::Cache::Counters::BufferCounter::Enqueuer.new(@options, source_object_class_name, relation_id, relation_type, "SuperCounter")
+
+        expect(worker_adapter).to receive(:enqueue).with(10,
+                                                         "BooUser",
+                                                         { relation_class_name: "Boo",
+                                                           relation_id: 1,
+                                                           column: "boo",
+                                                           method: "calculate_boo",
+                                                           cache: true,
+                                                           counter: "SuperCounter" })
       end
 
-      it "enqueues two jobs" do
-        expect(worker_adapter).to receive(:enqueue).with(20,
+      describe 'when recalculation is true' do
+        before do
+          expect(@options).to receive(:recalculation?).and_return(true)
+        end
+
+        it "enqueues two jobs" do
+          expect(@options).to receive(:touch_column).twice
+          expect(worker_adapter).to receive(:enqueue).with(20,
+                                                           "BooUser",
+                                                           { relation_class_name: "Boo",
+                                                             relation_id: 1,
+                                                             column: "boo",
+                                                             method: "calculate_boo",
+                                                             cache: false,
+                                                             counter: "SuperCounter" })
+          @enqueuer.enqueue!(double)
+        end
+      end
+
+      it 'enqueues one job' do
+        expect(@options).to receive(:touch_column)
+        @enqueuer.enqueue!(double)
+      end
+    end
+
+    context "with touch column" do
+      before(:each) do
+        @options = double(worker_adapter: worker_adapter,
+                          wait: 10,
+                          column: "boo",
+                          touch_column: "boo_updated_at",
+                          method: "calculate_boo",
+                          cached?: true,
+                          recalculation?: false,
+                          recalculation_delay: 20)
+        @enqueuer = Counter::Cache::Counters::BufferCounter::Enqueuer.new(@options, source_object_class_name, relation_id, relation_type, "SuperCounter")
+
+        expect(worker_adapter).to receive(:enqueue).with(10,
                                                          "BooUser",
                                                          { relation_class_name: "Boo",
                                                            relation_id: 1,
                                                            column: "boo",
                                                            touch_column: "boo_updated_at",
                                                            method: "calculate_boo",
-                                                           cache: false,
+                                                           cache: true,
                                                            counter: "SuperCounter" })
-        enqueuer.enqueue!(double)
       end
-    end
 
-    it 'enqueues one job' do
-      enqueuer.enqueue!(double)
+      describe 'when recalculation is true' do
+        before do
+          expect(@options).to receive(:recalculation?).and_return(true)
+        end
+
+        it "enqueues two jobs" do
+          expect(@options).to receive(:touch_column).exactly(4).times
+          expect(worker_adapter).to receive(:enqueue).with(20,
+                                                           "BooUser",
+                                                           { relation_class_name: "Boo",
+                                                             relation_id: 1,
+                                                             column: "boo",
+                                                             touch_column: "boo_updated_at",
+                                                             method: "calculate_boo",
+                                                             cache: false,
+                                                             counter: "SuperCounter" })
+          @enqueuer.enqueue!(double)
+        end
+      end
+
+      it 'enqueues one job' do
+        expect(@options).to receive(:touch_column)
+        @enqueuer.enqueue!(double)
+      end
     end
   end
 end

--- a/spec/lib/counter/cache/buffer_counter/enqueuer_spec.rb
+++ b/spec/lib/counter/cache/buffer_counter/enqueuer_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Enqueuer do
   let(:options) { double(worker_adapter: worker_adapter,
                          wait: 10,
                          column: "boo",
+                         touch_column: "boo_updated_at",
                          method: "calculate_boo",
                          cached?: true,
                          recalculation?: false,
@@ -23,6 +24,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Enqueuer do
                                                        { relation_class_name: "Boo",
                                                          relation_id: 1,
                                                          column: "boo",
+                                                         touch_column: "boo_updated_at",
                                                          method: "calculate_boo",
                                                          cache: true,
                                                          counter: "SuperCounter" })
@@ -39,6 +41,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Enqueuer do
                                                          { relation_class_name: "Boo",
                                                            relation_id: 1,
                                                            column: "boo",
+                                                           touch_column: "boo_updated_at",
                                                            method: "calculate_boo",
                                                            cache: false,
                                                            counter: "SuperCounter" })

--- a/spec/lib/counter/cache/buffer_counter/saver_spec.rb
+++ b/spec/lib/counter/cache/buffer_counter/saver_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
   end
 
   let(:relation_object) { double(boo_count: 2, boo_updated_at: DateTime.now) }
-  let(:options) { double(relation_class_name: "Boo", relation_id: 1, column: "boo_count", touch_column: "boo_updated_at", method: nil, source_object_class_name: Boo) }
+  let(:options) { double(relation_class_name: "Boo", relation_id: 1, column: "boo_count", method: nil, source_object_class_name: Boo) }
   let(:saver) { Counter::Cache::Counters::BufferCounter::Saver.new(options) }
 
   describe '#save!' do
@@ -21,8 +21,8 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
 
       before do
         allow(options).to receive(:cached?).and_return(true)
+        allow(options).to receive(:touch_column).and_return(nil)
         expect(relation_object).to receive(:boo_count=).with(4)
-        expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
         expect(relation_object).to receive(:save!)
         expect(counting_store).to receive(:del)
       end
@@ -42,16 +42,29 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
         expect(counting_store).to receive(:del)
       end
 
-      it 'saves the value' do
-        expect(relation_object).to receive(:boo_count=).with(4)
-        expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
-        expect(relation_object).to receive(:save!)
-        saver.save!
+      context "with touch column" do
+        it 'saves the value' do
+          allow(options).to receive(:touch_column).and_return(:boo_updated_at)
+          expect(relation_object).to receive(:boo_count=).with(4)
+          expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
+          expect(relation_object).to receive(:save!)
+          saver.save!
+        end
+      end
+
+      context "without touch column" do
+        it 'saves the value' do
+          allow(options).to receive(:touch_column).and_return(nil)
+          expect(relation_object).to receive(:boo_count=).with(4)
+          expect(relation_object).to receive(:save!)
+          saver.save!
+        end
       end
     end
 
     describe 'when cached? is false' do
       before do
+        allow(options).to receive(:touch_column).and_return(nil)
         allow(options).to receive(:cached?).and_return(false)
       end
 
@@ -63,7 +76,6 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
 
         it 'saves the value' do
           expect(relation_object).to receive(:boo_count=).with(4)
-          expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
           expect(relation_object).to receive(:save!)
           saver.save!
         end
@@ -78,7 +90,6 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
 
         it 'saves the value' do
           expect(relation_object).to receive(:boo_count=).with(4)
-          expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
           expect(relation_object).to receive(:save!)
           saver.save!
         end

--- a/spec/lib/counter/cache/buffer_counter/saver_spec.rb
+++ b/spec/lib/counter/cache/buffer_counter/saver_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
   class Boo
   end
 
-  let(:relation_object) { double(boo_count: 2) }
-  let(:options) { double(relation_class_name: "Boo", relation_id: 1, column: "boo_count", method: nil, source_object_class_name: Boo) }
+  let(:relation_object) { double(boo_count: 2, boo_updated_at: DateTime.now) }
+  let(:options) { double(relation_class_name: "Boo", relation_id: 1, column: "boo_count", touch_column: "boo_updated_at", method: nil, source_object_class_name: Boo) }
   let(:saver) { Counter::Cache::Counters::BufferCounter::Saver.new(options) }
 
   describe '#save!' do
@@ -22,6 +22,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
       before do
         allow(options).to receive(:cached?).and_return(true)
         expect(relation_object).to receive(:boo_count=).with(4)
+        expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
         expect(relation_object).to receive(:save!)
         expect(counting_store).to receive(:del)
       end
@@ -43,6 +44,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
 
       it 'saves the value' do
         expect(relation_object).to receive(:boo_count=).with(4)
+        expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
         expect(relation_object).to receive(:save!)
         saver.save!
       end
@@ -61,6 +63,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
 
         it 'saves the value' do
           expect(relation_object).to receive(:boo_count=).with(4)
+          expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
           expect(relation_object).to receive(:save!)
           saver.save!
         end
@@ -75,6 +78,7 @@ RSpec.describe Counter::Cache::Counters::BufferCounter::Saver do
 
         it 'saves the value' do
           expect(relation_object).to receive(:boo_count=).with(4)
+          expect(relation_object).to receive(:boo_updated_at=).with(DateTime.now)
           expect(relation_object).to receive(:save!)
           saver.save!
         end

--- a/spec/lib/counter/cache/options_parser_spec.rb
+++ b/spec/lib/counter/cache/options_parser_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe Counter::Cache::OptionsParser do
     end
   end
 
+  describe "#touch_column" do
+    let(:options) { { touch_column: "touch_column_name" } }
+    it "returns option if set" do
+      expect(parser.touch_column).to eq("touch_column_name")
+    end
+  end
+
   describe "#method" do
     let(:options) { { method: "method" } }
     it "returns option if set" do


### PR DESCRIPTION
Our counter caches also had touch columns on them to update when the counter was changed. Added this functionality for a clean transition to this gem.